### PR TITLE
feat: skip explicit docker login and use default config if no registry credentials are provided

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create v${{ steps.releaseVersion.outputs.result }} \
+            --target ${{ github.sha }} \
             --title "v${{ steps.releaseVersion.outputs.result }}" \
             --repo ${{ github.repository }} \
             --notes-file ${{ github.workspace }}/finalReleaseNotes.md \

--- a/examples/.docker/config.json
+++ b/examples/.docker/config.json
@@ -1,0 +1,8 @@
+{
+	"auths": {},
+	"credHelpers": {
+		"701831972387.dkr.ecr.us-east-1.amazonaws.com": "ecr-login",
+		"985174106285.dkr.ecr.us-east-1.amazonaws.com": "ecr-login",
+		"public.ecr.aws": "ecr-login"
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hooks",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hooks",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "Three projects are included - k8s: a kubernetes hook implementation that spins up pods dynamically to run a job - docker: A hook implementation of the runner's docker implementation  - A hook lib, which contains shared typescript definitions and utilities that the other packages consume",
   "main": "",
   "directories": {

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -20,6 +20,7 @@ export async function createContainer(
   if (!args.image) {
     throw new Error('Image was expected')
   }
+  core.debug(`ContainerInfo: ${JSON.stringify(args)}`)
 
   const dockerArgs: string[] = ['create']
   dockerArgs.push(`--label=${getRunnerLabel()}`)
@@ -98,9 +99,30 @@ export async function containerPull(
   }
   dockerArgs.push('pull')
   dockerArgs.push(image)
+
+  // If using the ECR docker credential helper, need to ensure that these environment variables
+  // are present in the shell of the docker pull command.
+  const containerPullCliEnvs = new Set([
+    'AWS_PROFILE',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_STS_REGIONAL_ENDPOINTS',
+    'AWS_DEFAULT_REGION',
+    'AWS_REGION',
+    'AWS_ROLE_ARN',
+    'AWS_WEB_IDENTITY_TOKEN_FILE',
+    'HOME',
+    'PATH'
+  ])
+  const dockerCliEnvs = {}
+  for (const key in process.env) {
+    if (containerPullCliEnvs.has(key)) {
+      dockerCliEnvs[key] = process.env[key]
+    }
+  }
   for (let i = 0; i < 3; i++) {
     try {
-      await runDockerCommand(dockerArgs)
+      await runDockerCommand(dockerArgs, { env: dockerCliEnvs })
       return
     } catch {
       core.info(`docker pull failed on attempt: ${i + 1}`)
@@ -290,8 +312,9 @@ export async function getContainerEnvValue(
 }
 
 export async function registryLogin(registry?: Registry): Promise<string> {
+  // if registry credentials are not provided, skip login and return default docker config location
   if (!registry) {
-    return ''
+    return env.DOCKER_CONFIG || `${env.HOME}/.docker`
   }
   const credentials = {
     username: registry.username,

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -48,6 +48,8 @@ export async function createContainer(
       dockerArgs.push(key)
     }
   }
+  // Explicitly set GITHUB_ACTIONS and CI env vars on the container
+  dockerArgs.push('-e', 'GITHUB_ACTIONS', '-e', 'CI')
 
   const mountVolumes = [
     ...(args.userMountVolumes || []),

--- a/packages/docker/src/hooks/run-container-step.ts
+++ b/packages/docker/src/hooks/run-container-step.ts
@@ -19,7 +19,9 @@ export async function runContainerStep(
     try {
       await containerPull(args.image, configLocation)
     } finally {
-      await registryLogout(configLocation)
+      if (args.registry) {
+        await registryLogout(configLocation)
+      }
     }
   } else if (args.dockerfile) {
     await containerBuild(args, tag)

--- a/packages/docker/src/index.ts
+++ b/packages/docker/src/index.ts
@@ -13,11 +13,12 @@ import {
   runContainerStep,
   runScriptStep
 } from './hooks'
-import { checkEnvironment } from './utils'
+import { checkEnvironment, cleanEnvironment } from './utils'
 
 async function run(): Promise<void> {
   try {
     checkEnvironment()
+    cleanEnvironment()
     const input = await getInputFromStdin()
 
     const args = input['args']

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -31,6 +31,8 @@ export function optionsWithDockerEnvs(
   options?: RunDockerCommandOptions
 ): RunDockerCommandOptions | undefined {
   // From https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
+  // These, combined with any variables provided via options.env,
+  // will be passed to the shell running the docker command
   const dockerCliEnvs = new Set([
     'DOCKER_API_VERSION',
     'DOCKER_CERT_PATH',
@@ -43,7 +45,9 @@ export function optionsWithDockerEnvs(
     'DOCKER_HOST',
     'DOCKER_STACK_ORCHESTRATOR',
     'DOCKER_TLS_VERIFY',
-    'BUILDKIT_PROGRESS'
+    'BUILDKIT_PROGRESS',
+    'GITHUB_ACTIONS',
+    'CI'
   ])
   const dockerEnvs = {}
   for (const key in process.env) {

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -70,6 +70,15 @@ export function optionsWithDockerEnvs(
   return newOptions
 }
 
+export function cleanEnvironment(): void {
+  const sensitiveEnvs = new Set(['AWS_SECRET_ACCESS_KEY', 'AWS_ACCESS_KEY_ID'])
+  for (const key in sensitiveEnvs) {
+    if (process.env[key]) {
+      core.setSecret(process.env[key] as string)
+    }
+  }
+}
+
 export function sanitize(val: string): string {
   if (!val || typeof val !== 'string') {
     return ''

--- a/packages/docker/tests/utils-test.ts
+++ b/packages/docker/tests/utils-test.ts
@@ -63,9 +63,14 @@ describe('Utilities', () => {
 
     it('should not overwrite other options', () => {
       process.env.DOCKER_HOST = 'unix:///run/user/1001/docker.sock'
+
       const opt = {
         workingDir: 'test',
-        input: Buffer.from('test')
+        input: Buffer.from('test'),
+        env: {
+          HOME: '/home/runner',
+          PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/runner/.local/bin/'
+        }
       }
 
       const options = optionsWithDockerEnvs(opt)
@@ -73,7 +78,11 @@ describe('Utilities', () => {
       expect(options?.workingDir).toBe(opt.workingDir)
       expect(options?.input).toBe(opt.input)
       expect(options?.env).toStrictEqual({
-        DOCKER_HOST: process.env.DOCKER_HOST
+        CI: process.env.CI,
+        GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+        DOCKER_HOST: process.env.DOCKER_HOST,
+        PATH: opt.env.PATH,
+        HOME: opt.env.HOME
       })
     })
   })

--- a/releaseNotes.md
+++ b/releaseNotes.md
@@ -1,10 +1,10 @@
-<!-- ## Features -->
+## Features
+
+- conditionally skip docker login step to fallback on default docker config if no registry credentials are provided
 
 <!-- ## Bugs -->
 
-## Misc
-
-- Bump `@kubernetes/client-node` from 0.18.1 to 0.22.0 in /packages/k8s [#182]
+<!-- ## Misc -->
 
 ## SHA-256 Checksums
 


### PR DESCRIPTION
To support replacing ECR Login Credentials with [amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper) in our CI workflows, this customizes the Docker [`prepare_job` Hook](https://github.com/actions/runner/blob/main/docs/adrs/1891-container-hooks.md#prepare_job-hook) to skip the `docker login` step and "fallback" to a default docker config location if no registry credentials are provided to the Hook, i.e. the [`container.credentials`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainercredentials) are not provided.

Additional changes of note:
- Passing additional environment variables to the docker command to support the Credential Helper (e.g. the `AWS_` vars)
- Setting the `GITHUB_ACTIONS` and `CI` environment variables to the container on creation (necessary for some of our internal logic/handling)


PR `#2a` of [Using Docker Credential Helpers for ECR Registries in GitHub Actions](https://www.notion.so/wrapbook/Using-Docker-Credential-Helpers-for-ECR-Registries-in-GitHub-Actions-18cfdd08fcdc80e689e2ea31bba623da)

[sc-135780](https://app.shortcut.com/wrapbook/story/135780)