### PR TITLE
Update docker env var, fix internal-runners auth error [sc-152621]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.7.2",
+  "version": "0.7.1",
   "description": "Three projects are included - k8s: a kubernetes hook implementation that spins up pods dynamically to run a job - docker: A hook implementation of the runner's docker implementation  - A hook lib, which contains shared typescript definitions and utilities that the other packages consume",
   "main": "",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "description": "Three projects are included - k8s: a kubernetes hook implementation that spins up pods dynamically to run a job - docker: A hook implementation of the runner's docker implementation  - A hook lib, which contains shared typescript definitions and utilities that the other packages consume",
   "main": "",
   "directories": {

--- a/packages/docker/src/dockerCommands/container.ts
+++ b/packages/docker/src/dockerCommands/container.ts
@@ -316,7 +316,7 @@ export async function getContainerEnvValue(
 export async function registryLogin(registry?: Registry): Promise<string> {
   // if registry credentials are not provided, skip login and return default docker config location
   if (!registry) {
-    return env.DOCKER_CONFIG || `${env.HOME}/.docker`
+    return env.DOCKER_CONFIG_CI_RUNNERS || `${env.HOME}/.docker`
   }
   const credentials = {
     username: registry.username,

--- a/packages/docker/src/utils.ts
+++ b/packages/docker/src/utils.ts
@@ -36,7 +36,7 @@ export function optionsWithDockerEnvs(
   const dockerCliEnvs = new Set([
     'DOCKER_API_VERSION',
     'DOCKER_CERT_PATH',
-    'DOCKER_CONFIG',
+    'DOCKER_CONFIG_CI_RUNNERS',
     'DOCKER_CONTENT_TRUST_SERVER',
     'DOCKER_CONTENT_TRUST',
     'DOCKER_CONTEXT',

--- a/releaseNotes.md
+++ b/releaseNotes.md
@@ -1,6 +1,6 @@
 ## Features
 
-- conditionally skip docker login step to fallback on default docker config if no registry credentials are provided
+- Update environment variable `DOCKER_CONFIG` to `DOCKER_CONFIG_CI_RUNNER` to avoid conflicts with other Docker configurations.
 
 <!-- ## Bugs -->
 


### PR DESCRIPTION
Update name of Docker CLI environment variable `DOCKER_CONFIG` to `DOCKER_CONFIG_CI_RUNNERS` so as not to step on any default Docker env vars.

New [release `v0.7.1`](https://github.com/wrapbook/runner-container-hooks/releases/tag/v0.7.1) has been published and tested.

More details in https://app.shortcut.com/wrapbook/story/152621/update-docker-config-env-var-for-gha-internal-runners